### PR TITLE
fix: UX improvements and maintenance — addresses #21

### DIFF
--- a/src/packages/cli/__tests__/cli.test.ts
+++ b/src/packages/cli/__tests__/cli.test.ts
@@ -3,10 +3,13 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 // Helper function to run CLI commands and capture output
-function runCLI(args: string[], input?: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+function runCLI(
+  args: string[],
+  input?: string,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
   return new Promise((resolve) => {
     const child = spawn("node", ["dist/index.js", ...args], {
-      stdio: ["pipe", "pipe", "pipe"]
+      stdio: ["pipe", "pipe", "pipe"],
     });
 
     let stdout = "";
@@ -28,7 +31,7 @@ function runCLI(args: string[], input?: string): Promise<{ stdout: string; stder
       resolve({
         stdout: stdout.trim(),
         stderr: stderr.trim(),
-        exitCode: code ?? 0
+        exitCode: code ?? 0,
       });
     });
 
@@ -42,8 +45,6 @@ function runCLI(args: string[], input?: string): Promise<{ stdout: string; stder
   });
 }
 
-
-
 describe("Gronify CLI", () => {
   const testJSONFile = join(process.cwd(), "__tests__", "test.json");
   const testGronFile = join(process.cwd(), "__tests__", "test.gron");
@@ -52,23 +53,23 @@ describe("Gronify CLI", () => {
 
   beforeAll(() => {
     // Read test data from files
-    testJSON = JSON.parse(readFileSync(testJSONFile, 'utf8'));
-    testGron = readFileSync(testGronFile, 'utf8');
+    testJSON = JSON.parse(readFileSync(testJSONFile, "utf8"));
+    testGron = readFileSync(testGronFile, "utf8");
   });
 
   describe("flatten command", () => {
     test("should flatten JSON from stdin", async () => {
       const result = await runCLI(["flatten"], JSON.stringify(testJSON));
-      
+
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("json = {}");
       expect(result.stdout).toContain("json.user.id = 12345");
-      expect(result.stdout).toContain("json.user.name = \"Alice\"");
+      expect(result.stdout).toContain('json.user.name = "Alice"');
     });
 
     test("should show error for non-existent file", async () => {
       const result = await runCLI(["flatten", "nonexistent.json"]);
-      
+
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("does not exist");
     });
@@ -77,7 +78,7 @@ describe("Gronify CLI", () => {
   describe("unflatten command", () => {
     test("should unflatten gron file", async () => {
       const result = await runCLI(["unflatten", testGronFile]);
-      
+
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.user.id).toBe(12345);
@@ -87,7 +88,7 @@ describe("Gronify CLI", () => {
 
     test("should unflatten gron from stdin", async () => {
       const result = await runCLI(["unflatten"], testGron);
-      
+
       expect(result.exitCode).toBe(0);
       const parsed = JSON.parse(result.stdout);
       expect(parsed.user.id).toBe(12345);
@@ -96,7 +97,7 @@ describe("Gronify CLI", () => {
 
     test("should show error for non-existent file", async () => {
       const result = await runCLI(["unflatten", "nonexistent.gron"]);
-      
+
       expect(result.exitCode).toBe(1);
       expect(result.stderr).toContain("does not exist");
     });
@@ -105,46 +106,94 @@ describe("Gronify CLI", () => {
   describe("search command", () => {
     test("should search in JSON file", async () => {
       const result = await runCLI(["search", testJSONFile, "user"]);
-      
+
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("json.user");
     });
 
     test("should search case sensitively", async () => {
-      const result = await runCLI(["search", testJSONFile, "Alice", "--case-sensitive"]);
-      
+      const result = await runCLI([
+        "search",
+        testJSONFile,
+        "Alice",
+        "--case-sensitive",
+      ]);
+
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("json.user.name = \"Alice\"");
+      expect(result.stdout).toContain('json.user.name = "Alice"');
     });
 
     test("should count matches", async () => {
       const result = await runCLI(["search", testJSONFile, "post", "--count"]);
-      
+
       expect(result.exitCode).toBe(0);
       expect(parseInt(result.stdout)).toBeGreaterThan(0);
     });
 
     test("should search from stdin", async () => {
       const result = await runCLI(["search", "user"], JSON.stringify(testJSON));
-      
+
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("json.user");
     });
 
     test("should show no matches found", async () => {
       const result = await runCLI(["search", testJSONFile, "nonexistent"]);
-      
+
       expect(result.exitCode).toBe(0); // No matches is not an error
       expect(result.stderr).toContain("No matches found");
+    });
+
+    test("should support --invert-match flag", async () => {
+      const result = await runCLI([
+        "search",
+        testJSONFile,
+        "user",
+        "--invert-match",
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      // Should contain lines that don't have "user" in them
+      expect(result.stdout).toContain("json.posts");
+      expect(result.stdout).not.toContain("json.user");
+    });
+  });
+
+  describe("output file option", () => {
+    test("should write flatten output to file with -o", async () => {
+      const outputFile = join(process.cwd(), "__tests__", "test-output.gron");
+      const result = await runCLI([
+        "--no-color",
+        "-o",
+        outputFile,
+        "flatten",
+        testJSONFile,
+      ]);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("Output written to");
+      // Verify the file was written
+      const content = readFileSync(outputFile, "utf8");
+      expect(content).toContain("json.user.id = 12345");
+
+      // Clean up
+      const { unlinkSync } = await import("fs");
+      try {
+        unlinkSync(outputFile);
+      } catch {
+        /* ignore */
+      }
     });
   });
 
   describe("help and version", () => {
     test("should show help", async () => {
       const result = await runCLI(["--help"]);
-      
+
       expect(result.exitCode).toBe(0);
-      expect(result.stdout).toContain("Flatten, search, and unflatten JSON from the command line");
+      expect(result.stdout).toContain(
+        "Flatten, search, and unflatten JSON from the command line",
+      );
       expect(result.stdout).toContain("flatten");
       expect(result.stdout).toContain("unflatten");
       expect(result.stdout).toContain("search");
@@ -152,14 +201,14 @@ describe("Gronify CLI", () => {
 
     test("should show version", async () => {
       const result = await runCLI(["--version"]);
-      
+
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("1.0.0");
     });
 
     test("should show command help", async () => {
       const result = await runCLI(["search", "--help"]);
-      
+
       expect(result.exitCode).toBe(0);
       expect(result.stdout).toContain("Search through flattened JSON paths");
       expect(result.stdout).toContain("--regex");

--- a/src/packages/cli/__tests__/formatter.test.ts
+++ b/src/packages/cli/__tests__/formatter.test.ts
@@ -1,0 +1,216 @@
+// Mock chalk to avoid ESM issues in jest's CommonJS environment
+jest.mock("chalk", () => {
+  const wrap = (s: string) => s;
+  return {
+    default: {
+      red: wrap,
+      green: wrap,
+      yellow: wrap,
+      blue: wrap,
+      magenta: wrap,
+      cyan: wrap,
+      gray: wrap,
+      bgYellow: {
+        black: wrap,
+      },
+    },
+  };
+});
+
+import {
+  OutputFormatter,
+  createFormatter,
+  shouldUseColor,
+} from "../src/formatter";
+
+// Save and restore environment variables for consistent tests
+const originalEnv = { ...process.env };
+const originalIsTTY = process.stdout.isTTY;
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  // @ts-expect-error: writable for tests
+  process.stdout.isTTY = originalIsTTY;
+});
+
+describe("OutputFormatter", () => {
+  describe("constructor", () => {
+    test("should use default options", () => {
+      const fmt = new OutputFormatter({ color: false });
+      expect(fmt).toBeInstanceOf(OutputFormatter);
+    });
+
+    test("should disable color when NO_COLOR is set", () => {
+      process.env.NO_COLOR = "1";
+      // @ts-expect-error: writable for tests
+      process.stdout.isTTY = true;
+      const fmt = new OutputFormatter();
+      // Color should be disabled because NO_COLOR is set
+      const output = fmt.formatError("test error");
+      expect(output).toBe("Error: test error");
+    });
+
+    test("should disable color when not in TTY", () => {
+      delete process.env.NO_COLOR;
+      // @ts-expect-error: writable for tests
+      process.stdout.isTTY = false;
+      const fmt = new OutputFormatter();
+      const output = fmt.formatError("test error");
+      expect(output).toBe("Error: test error");
+    });
+  });
+
+  describe("formatError", () => {
+    test("should format error messages without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      expect(fmt.formatError("File not found")).toBe("Error: File not found");
+    });
+
+    test("should not return undefined", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const output = fmt.formatError("test");
+      expect(output).toBeDefined();
+      expect(output.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("formatWarning", () => {
+    test("should format warning messages without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      expect(fmt.formatWarning("Deprecated")).toBe("Warning: Deprecated");
+    });
+  });
+
+  describe("formatSuccess", () => {
+    test("should format success messages without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      expect(fmt.formatSuccess("Done!")).toBe("Done!");
+    });
+  });
+
+  describe("formatInfo", () => {
+    test("should format info messages without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      expect(fmt.formatInfo("Tip: use --help")).toBe("Tip: use --help");
+    });
+  });
+
+  describe("formatGron", () => {
+    test("should format simple gron output", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const input = 'json = {}\njson.name = "test"\njson.count = 42';
+      const output = fmt.formatGron(input);
+      expect(output).toContain("json = {}");
+      expect(output).toContain('json.name = "test"');
+      expect(output).toContain("json.count = 42");
+    });
+
+    test("should handle empty input", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const output = fmt.formatGron("");
+      expect(output).toBe("");
+    });
+
+    test("should handle whitespace-only input", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const output = fmt.formatGron("   \n   \n");
+      expect(output).toBe("");
+    });
+
+    test("should handle pretty formatting option", () => {
+      const fmt = new OutputFormatter({ color: false, pretty: true });
+      const input = 'json = {}\njson.name = "test"';
+      const output = fmt.formatGron(input);
+      expect(output).toContain("json = {}");
+      expect(output).toContain('json.name = "test"');
+    });
+  });
+
+  describe("formatJson", () => {
+    test("should format JSON without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const input = '{"name":"test","value":42}';
+      const output = fmt.formatJson(input);
+      expect(output).toContain('"name"');
+      expect(output).toContain('"test"');
+      expect(output).toContain("42");
+    });
+
+    test("should pretty-print JSON when option is set", () => {
+      const fmt = new OutputFormatter({ color: false, pretty: true });
+      const input = '{"name":"test","value":42}';
+      const output = fmt.formatJson(input);
+      // Pretty-printed JSON should have newlines and indentation
+      expect(output).toContain("\n");
+      expect(output).toContain('  "name"');
+    });
+
+    test("should handle invalid JSON gracefully", () => {
+      const fmt = new OutputFormatter({ color: false, pretty: true });
+      const input = "not valid json";
+      // Should not throw, should return original input
+      const output = fmt.formatJson(input);
+      expect(output).toBe("not valid json");
+    });
+  });
+
+  describe("formatSearchResults", () => {
+    test("should format search results without color", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const results = 'json.name = "Alice"\njson.id = 12345';
+      const output = fmt.formatSearchResults(results, "Alice");
+      expect(output).toContain("json.name");
+      expect(output).toContain("Alice");
+    });
+
+    test("should handle empty results", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const output = fmt.formatSearchResults("", "test");
+      expect(output).toBe("");
+    });
+
+    test("should escape special regex characters in search term", () => {
+      const fmt = new OutputFormatter({ color: false });
+      const results = 'json.path = "test(value)"';
+      // Should not throw with special characters
+      expect(() =>
+        fmt.formatSearchResults(results, "test(value)"),
+      ).not.toThrow();
+    });
+  });
+});
+
+describe("createFormatter", () => {
+  test("should create an OutputFormatter instance", () => {
+    const fmt = createFormatter({ color: false });
+    expect(fmt).toBeInstanceOf(OutputFormatter);
+  });
+
+  test("should create with default options when none provided", () => {
+    const fmt = createFormatter();
+    expect(fmt).toBeInstanceOf(OutputFormatter);
+  });
+});
+
+describe("shouldUseColor", () => {
+  test("should return false when NO_COLOR is set", () => {
+    process.env.NO_COLOR = "1";
+    expect(shouldUseColor()).toBe(false);
+  });
+
+  test("should return false when stdout is not TTY", () => {
+    delete process.env.NO_COLOR;
+    // @ts-expect-error: writable for tests
+    process.stdout.isTTY = false;
+    expect(shouldUseColor()).toBe(false);
+  });
+
+  test("should return false when stdin is not TTY", () => {
+    delete process.env.NO_COLOR;
+    // @ts-expect-error: writable for tests
+    process.stdout.isTTY = true;
+    // @ts-expect-error: writable for tests
+    process.stdin.isTTY = false;
+    expect(shouldUseColor()).toBe(false);
+  });
+});

--- a/src/packages/cli/jest.config.cjs
+++ b/src/packages/cli/jest.config.cjs
@@ -1,19 +1,19 @@
 /** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  testMatch: ['**/__tests__/**/*.test.ts'],
-  collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.d.ts',
-  ],
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testMatch: ["**/__tests__/**/*.test.ts"],
+  collectCoverageFrom: ["src/**/*.ts", "!src/**/*.d.ts"],
   // Modern ts-jest configuration
   transform: {
-    '^.+\\.ts$': ['ts-jest', {
-      tsconfig: {
-        module: 'commonjs',
-        target: 'es2020',
-      }
-    }],
+    "^.+\\.ts$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          module: "commonjs",
+          target: "es2020",
+        },
+      },
+    ],
   },
 };

--- a/src/packages/cli/src/formatter.ts
+++ b/src/packages/cli/src/formatter.ts
@@ -204,34 +204,6 @@ export class OutputFormatter {
   }
 
   /**
-   * Apply pretty formatting with indentation and grouping
-   */
-  private applyPrettyFormatting(lines: string[]): string[] {
-    const result: string[] = [];
-    let lastTopLevel = '';
-
-    lines.forEach((line, index) => {
-      // Calculate indentation based on nesting level
-      const nestingLevel = Math.max(0, (line.match(/\[/g) || []).length + (line.match(/\./g) || []).length - 1);
-      const indent = '  '.repeat(Math.min(nestingLevel, 6)); // Max 6 levels
-      
-      // Extract top-level object (e.g., "users" from "json.users[0].name")
-      const topLevelMatch = line.match(/^json\.([^\[.]+)/);
-      const currentTopLevel = topLevelMatch ? topLevelMatch[1] : 'root';
-      
-      // Add spacing between different top-level objects
-      if (index > 0 && currentTopLevel !== lastTopLevel && lastTopLevel !== 'root') {
-        result.push('');
-      }
-      
-      result.push(indent + line);
-      lastTopLevel = currentTopLevel || 'root';
-    });
-
-    return result;
-  }
-
-  /**
    * Apply pretty formatting to already colored lines
    */
   private applyPrettyFormattingToColoredLines(lines: string[]): string[] {

--- a/src/packages/cli/src/index.ts
+++ b/src/packages/cli/src/index.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from "commander";
 import { spawn } from "node:child_process";
-import { existsSync, accessSync, constants, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, accessSync, constants, writeFileSync, mkdirSync, unlinkSync } from "node:fs";
 import { extname, join } from "node:path";
 import { tmpdir } from "node:os";
 import { createFormatter, shouldUseColor, type FormatOptions } from "./formatter.js";
@@ -15,7 +15,8 @@ program
   .version("1.0.0")
   .option("--color", "Enable colored output (default: auto-detect)")
   .option("--no-color", "Disable colored output")
-  .option("--pretty", "Enable pretty formatting with better readability");
+  .option("--pretty", "Enable pretty formatting with better readability")
+  .option("-o, --output <file>", "Write output to a file instead of stdout");
 
 // Helper function to check if stdin has data
 function hasStdinData(): boolean {
@@ -85,7 +86,7 @@ function validateFile(filePath: string, allowMissing = false): void {
 }
 
 // Helper function to run fastgron with formatting
-function runFastgron(args: string[], formatter: import("./formatter.js").OutputFormatter, onError?: (code: number) => void): void {
+function runFastgron(args: string[], formatter: import("./formatter.js").OutputFormatter, onError?: (code: number) => void, outputFile?: string): void {
   const p = spawn("fastgron", args, { stdio: ["inherit", "pipe", "pipe"] });
 
   let stdout = "";
@@ -123,10 +124,20 @@ function runFastgron(args: string[], formatter: import("./formatter.js").OutputF
       // Check if this is gron output (flatten) or JSON output (unflatten)
       const isGronOutput = args.includes("-u") ? false : true;
       
-      if (isGronOutput) {
-        console.log(formatter.formatGron(stdout.trim()));
+      const formatted = isGronOutput
+        ? formatter.formatGron(stdout.trim())
+        : formatter.formatJson(stdout.trim());
+
+      if (outputFile) {
+        try {
+          writeFileSync(outputFile, formatted + "\n", "utf8");
+          console.error(formatter.formatSuccess(`Output written to ${outputFile}`));
+        } catch (err: any) {
+          console.error(formatter.formatError(`writing to ${outputFile}: ${err.message}`));
+          process.exit(1);
+        }
       } else {
-        console.log(formatter.formatJson(stdout.trim()));
+        console.log(formatted);
       }
     }
 
@@ -180,8 +191,8 @@ program
       // Clean up temporary file if created
       if (isTemporary) {
         try {
-          require('fs').unlinkSync(inputFile);
-        } catch (error) {
+          unlinkSync(inputFile);
+        } catch {
           // Ignore cleanup errors
         }
       }
@@ -189,9 +200,10 @@ program
       if (code === 1) {
         console.error(formatter.formatError("This might indicate invalid JSON in the input"));
         console.error("Please check that your JSON is valid");
+        console.error(formatter.formatInfo("Tip: Validate your JSON with a linter like https://jsonlint.com"));
       }
       process.exit(code);
-    });
+    }, globalOptions.output);
   });
 
 // Unflatten command
@@ -231,8 +243,8 @@ program
       // Clean up temporary file if created
       if (isTemporary) {
         try {
-          require('fs').unlinkSync(inputFile);
-        } catch (error) {
+          unlinkSync(inputFile);
+        } catch {
           // Ignore cleanup errors
         }
       }
@@ -240,9 +252,10 @@ program
       if (code === 1) {
         console.error(formatter.formatError("This might indicate invalid gron format in the input"));
         console.error("Please check that your gron file is properly formatted");
+        console.error(formatter.formatInfo("Tip: Gron lines should look like: json.path = value"));
       }
       process.exit(code);
-    });
+    }, globalOptions.output);
   });
 
 // Search command
@@ -254,10 +267,12 @@ program
   .option("-r, --regex", "Use regex pattern matching")
   .option("-c, --case-sensitive", "Case sensitive search")
   .option("--count", "Show only the count of matches")
+  .option("-v, --invert-match", "Invert match: show lines that do NOT match")
   .action(async (fileOrTerm: string, term: string | undefined, options: {
     regex?: boolean;
     caseSensitive?: boolean;
     count?: boolean;
+    invertMatch?: boolean;
   }, command?: any) => {
     const globalOptions = command?.parent?.opts() || {};
     const formatter = createFormatterFromOptions(globalOptions);
@@ -310,6 +325,11 @@ program
     if (options.regex) {
       grepArgs.push("-E"); // Extended regex
     }
+
+    // Invert match
+    if (options.invertMatch) {
+      grepArgs.push("-v");
+    }
     
     // Add the search term
     grepArgs.push(searchTerm);
@@ -338,8 +358,8 @@ program
     const cleanupTempFile = () => {
       if (isTemporary) {
         try {
-          require('fs').unlinkSync(inputFile);
-        } catch (error) {
+          unlinkSync(inputFile);
+        } catch {
           // Ignore cleanup errors
         }
       }
@@ -383,7 +403,12 @@ program
       
       if (code === 1) {
         if (!options.count) {
-          console.error(formatter.formatWarning(`No matches found for '${searchTerm}'`));
+          if (options.invertMatch) {
+            console.error(formatter.formatWarning(`All lines matched '${searchTerm}' (nothing to invert)`));
+          } else {
+            console.error(formatter.formatWarning(`No matches found for '${searchTerm}'`));
+            console.error(formatter.formatInfo(`Tip: Try --case-sensitive or --regex for different matching`));
+          }
         }
         process.exit(0); // This is not an error, just no matches
       } else if (code && code > 1) {


### PR DESCRIPTION
## Summary

Addresses issue #21 (Ongoing maintenance and user experience enhancements).

## Changes

### Bug Fixes
- **Fix ESM compatibility**: Replace `require('fs').unlinkSync` with imported `unlinkSync`. The CLI is an ESM module (`"type": "module"`), but three places used CommonJS `require('fs')` for temp file cleanup. This could cause runtime errors in strict ESM environments.

### New Features
- **`-o, --output <file>` flag**: Write flatten/unflatten output to a file instead of stdout. Useful for scripting and piping.
- **`-v, --invert-match` flag for search**: Show lines that do NOT match the search term (like `grep -v`).

### UX Improvements
- Added helpful tips to error messages (e.g., "Tip: Validate your JSON with a linter like https://jsonlint.com")
- Better messaging for `--invert-match` when all lines match (nothing to invert)
- Search "no matches" message now suggests `--case-sensitive` or `--regex`

### Code Cleanup
- Removed dead code: `applyPrettyFormatting()` method was never called (only `applyPrettyFormattingToColoredLines()` is used)

### Tests
- **23 new unit tests** for the formatter module covering: error/warning/success/info formatting, gron formatting, JSON formatting, search results, color detection
- **2 new CLI tests** for `--invert-match` and `--output` features
- Mocked chalk in formatter tests to resolve ESM/CommonJS jest conflict

## Test Results
```
Test Suites: 2 passed, 2 total
Tests:       38 passed, 38 total
```

All checks pass: build, lint, format check, and metadata validation.

Closes #21